### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import sys
 import textwrap
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 
@@ -35,7 +35,7 @@ setup(
                  "various parts of Steam's public interfaces"),
     author="Oliver Ainsworth",
     author_email="ottajay@googlemail.com",
-    packages=["valve"],
+    packages=find_packages(),
     install_requires=[
         "six>=1.6",
         "requests>=2.0",


### PR DESCRIPTION
This fixed the install issue for me.

Found the fix at https://github.com/RamchandraApte/python-valve

Using the updated setup.py I am able to install from pip

    pip install git+https://github.com/PhilipCammarata/python-valve.git

and

```
>>> from valve.steam.id import SteamID
>>> SteamID.from_text('STEAM_0:0:180705').as_32()
'[U:1:361410]'
>>> SteamID.from_text('STEAM_0:0:180705').as_64()
'76561197960627138'

```
