### PR TITLE
fix rulesresponse for quake live

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,8 +77,9 @@ def pytest_generate_tests(metafunc):
         msq = valve.source.master_server.MasterServerQuerier()
         server_addresses = []
         address_limit = metafunc.config.getoption("srcds_functional_limit")
+        region = metafunc.function._srcds_filter.pop('region', 'eu')
         try:
-            for address in msq.find(region="eu",
+            for address in msq.find(region=region,
                                     **metafunc.function._srcds_filter):
                 if address_limit:
                     if len(server_addresses) >= address_limit:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,15 @@ def test_tf2_info(address):
     assert info["folder"] == "tf"
     assert isinstance(info["folder"], six.text_type)
 
+    
+@pytest.srcds_functional(gamedir="tf")
+def test_tf2_rules(address):
+    try:
+        a2s = valve.source.a2s.ServerQuerier(address)
+        rules = a2s.get_rules()
+    except valve.source.a2s.NoResponseError:
+        pytest.skip("Timedout waiting for response")
+
 
 @pytest.srcds_functional(gamedir="cstrike")
 def test_css_ping(address):
@@ -140,3 +149,14 @@ def test_l4d2_info(address):
     assert info["app_id"] == 550
     assert info["folder"] == "left4dead2"
     assert isinstance(info["folder"], six.text_type)
+
+    
+# quake live
+@pytest.srcds_functional(region='rest', appid='282440')
+def test_ql_rules(address):
+    try:
+        a2s = valve.source.a2s.ServerQuerier(address)
+        rules = a2s.get_rules()
+    except valve.source.a2s.NoResponseError:
+        return
+    

--- a/valve/source/messages.py
+++ b/valve/source/messages.py
@@ -518,12 +518,6 @@ class RulesRequest(Message):
 class RulesResponse(Message):
 
     fields = (
-        # A2S_RESPONSE misteriously seems to add a FF FF FF FF
-        # long to the beginning of the response which isn't
-        # mentioned on the wiki.
-        #
-        # Behaviour witnessed with TF2 server 94.23.226.200:2045
-        LongField("long"),
         ByteField("response_type", validators=[lambda x: x == 0x45]),
         ShortField("rule_count"),
         MessageDictField("rules",
@@ -532,6 +526,17 @@ class RulesResponse(Message):
                          MessageArrayField.value_of("rule_count"))
     )
 
+    @classmethod
+    def decode(cls, packet):
+        # A2S_RESPONSE misteriously seems to add a FF FF FF FF
+        # long to the beginning of the response which isn't
+        # mentioned on the wiki.
+        #
+        # Behaviour witnessed with TF2 server 94.23.226.200:2045
+        # As of 2015-11-22, Quake Live servers on steam do not
+        if packet.startswith(b'\xff\xff\xff\xff'):
+            packet = packet[4:]
+        return super(cls, RulesResponse).decode(packet)
 
 # For Master Server
 class MSAddressEntryPortField(MessageField):


### PR DESCRIPTION
Quake Live recently moved to steam, this fixes the ServerQuerier.get_rules() call on their servers. Here's a small program that shows this works on python 3.4:

```
import valve
import valve.source.master_server

from valve.source.a2s import ServerQuerier as SQ

msq = valve.source.master_server.MasterServerQuerier(timeout=None)
addr = list(msq.find(region='rest', appid='282440', empty=1, secure=1, gametype=['FFA']))
server = SQ(addr[0])
info = server.get_info()
rules = server.get_rules()
print(rules.values)
```