### PR TITLE
Changed get_info() to info() in tests and documentation for commit 47dc6b0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ try:
                             gamedir=u"tf",
                             map=u"ctf_2fort"):
         server = valve.source.a2s.ServerQuerier(address)
-        info = server.get_info()
+        info = server.info()
         players = server.get_players()
 
         print "{player_count}/{max_players} {server_name}".format(**info)

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -23,7 +23,7 @@ score-decesending.
     SERVER_ADDRESS = (..., ...)
 
     server = valve.source.a2s.ServerQuerier(SERVER_ADDRESS)
-    info = server.get_info()
+    info = server.info()
     players = server.get_players()
 
     print "{player_count}/{max_players} {server_name}".format(**info)

--- a/valve/source/a2s.py
+++ b/valve/source/a2s.py
@@ -55,7 +55,7 @@ class ServerQuerier(BaseServerQuerier):
         # "TF2 currently does not split replies, expect A2S_PLAYER and
         # A2S_RULES to be simply cut off after 1260 bytes."
         #
-        # However whilst testing get_info() on a TF2 server, it did
+        # However whilst testing info() on a TF2 server, it did
         # set the split header to -2. So it is unclear whether the
         # warning means that only one fragment of the message is sent
         # or that the warning is no longer valid.
@@ -98,7 +98,7 @@ class ServerQuerier(BaseServerQuerier):
         .. code:: python
 
             server = ServerQuerier(...)
-            print server.get_info()["server_name"]
+            print server.info()["server_name"]
 
         The following fields are available on the response:
 


### PR DESCRIPTION
I ran into issues running tests after pulling from the master repository.

Get_info() was changed to info() in commit 47dc6b0 on github.