### PR TITLE
Fix ResourceWarning being raised when querying in a loop due to unclosed socket object

### DIFF
--- a/valve/source/a2s.py
+++ b/valve/source/a2s.py
@@ -36,6 +36,9 @@ class BaseServerQuerier(object):
             raise NoResponseError(exc)
         return data
 
+    def __del__(self):
+        self.socket.close()
+
 
 class ServerQuerier(BaseServerQuerier):
     """Implements the A2S Source server query protocol


### PR DESCRIPTION
Added a **del** to BaseServerQuerier that automatically closes the socket.
